### PR TITLE
feat(config): support button spacing from config

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -328,6 +328,19 @@ int read_cfg(const char *cfg_path, struct Config *st, button *buttons_cfg[N]) {
             if (!quiet)
                 fprintf(stderr, "Error in the '%s' button configuration: invalid/missing values. Exiting.\n", button_names[i]);
         }
+
+		if (!config_lookup_int(&cfg, "row_gap", &st->row_gap)) {
+			if (!quiet)
+				fprintf(stderr, "Error in '%s': invalid 'row_gap'. Using default.\n", cfg_path);
+			st->row_gap = 10;  // valor padrão
+		}
+
+		if (!config_lookup_int(&cfg, "column_gap", &st->column_gap)) {
+    		if (!quiet)
+    	   		fprintf(stderr, "Error in '%s': invalid 'column_gap'. Using default.\n", cfg_path);
+	    	st->column_gap = 10;  // valor padrão
+		}
+
     }
     
     config_destroy(&cfg);

--- a/src/conf.h
+++ b/src/conf.h
@@ -37,6 +37,8 @@ struct Config {
     int columns;
     char *top_text;
     char *bottom_text;
+    int column_gap;
+    int row_gap;
 };
 
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,8 @@ int main(int argc, char *argv[]) {
     GtkWidget *grid = gtk_grid_new();
     gtk_grid_set_row_homogeneous(GTK_GRID(grid), TRUE);
     gtk_grid_set_column_homogeneous(GTK_GRID(grid), TRUE);
+    gtk_grid_set_row_spacing(GTK_GRID(grid), config.row_gap);
+    gtk_grid_set_column_spacing(GTK_GRID(grid), config.column_gap);
     gtk_container_add(GTK_CONTAINER(window), grid);
 
     if (strcmp(config.top_text, "")) {

--- a/tschuss.conf
+++ b/tschuss.conf
@@ -2,6 +2,8 @@ top_text = "";
 bottom_text = "";
 border_width = 0;
 columns = 3;
+row_gap = 5;
+column_gap = 5;
 
 size = {
     width = 600;


### PR DESCRIPTION
- Added `row_gap` and `column_gap` fields to `struct Config`.
- Updated `read_cfg()` to read these values from the config file.
- Set default values if the config is missing or invalid.
- Set in `main.c` the gap values using `gtk_grid_set_row_spacing()` and `gtk_grid_set_column_spacing`.